### PR TITLE
Post V1 Fix: add webkit-appearance none to ThemeMenu btn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdaworks-website",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdaworks-website",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@fontsource/outfit": "^5.0.8",
         "@fontsource/plus-jakarta-sans": "^5.0.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdaworks-website",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/ThemeMenu.tsx
+++ b/src/ThemeMenu.tsx
@@ -138,7 +138,7 @@ const ThemeMenu = () => {
           {/* Button Section */}
           <DropdownMenu.Trigger asChild>
             <button
-              className="rounded-full w-[26px] h-[26px] inline-flex items-center justify-center text-zdaBlue-600 dark:text-zdaBlue-500 bg-zdaBG-lightCard dark:bg-zdaBG-darkCard shadow-[0_1px_8px] shadow-slate-400 hover:shadow-slate-400/25 dark:shadow-zdaBlue-500/60 dark:hover:shadow-zdaBlue-500/25 outline outline-1 outline-zdaBlue-500/25 dark:outline-zdaBlue-500/15 hover:bg-zdaBlue-500/25 dark:hover:bg-zdaBlue-400/25 active:bg-zdaBlue-400/50 dark:active:bg-zdaBlue-500/50 transition ease-out duration-300 3xl:w-[31px] 3xl:h-[31px] 4xl:w-[34px] 4xl:h-[34px] 4k:w-[40px] 4k:h-[40px]"
+              className="rounded-full w-[26px] h-[26px] inline-flex items-center justify-center text-zdaBlue-600 dark:text-zdaBlue-500 bg-zdaBG-lightCard dark:bg-zdaBG-darkCard shadow-[0_1px_8px] shadow-slate-400 hover:shadow-slate-400/25 dark:shadow-zdaBlue-500/60 dark:hover:shadow-zdaBlue-500/25 outline outline-1 outline-zdaBlue-500/25 dark:outline-zdaBlue-500/15 hover:bg-zdaBlue-500/25 dark:hover:bg-zdaBlue-400/25 active:bg-zdaBlue-400/50 dark:active:bg-zdaBlue-500/50 transition ease-out duration-300 3xl:w-[31px] 3xl:h-[31px] 4xl:w-[34px] 4xl:h-[34px] 4k:w-[40px] 4k:h-[40px] webkit-appearance-none"
               aria-label="Theme Menu"
               title="Theme Menu"
               onClick={() => setOpen((prev) => !prev)}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+/* TAILWIND CSS EXTENSIONS */
+@layer components {
+  .webkit-appearance-none {
+    -webkit-appearance: none;
+  }
+}
+/* -- */
+
 :root {
   font-family: "Plus Jakarta Sans", Outfit, system-ui, Avenir,
     Helvetica, Arial, sans-serif;


### PR DESCRIPTION
NOTE: Can add more custom vendor-prefix and etc styles using the `@layer` in the `index.css`!