### PR TITLE
Fix: add robots txt and correct theme color in manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdaworks-website",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdaworks-website",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@fontsource/outfit": "^5.0.8",
         "@fontsource/plus-jakarta-sans": "^5.0.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdaworks-website",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,6 +15,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#29242a",
-  "background_color": "#29242a"
+  "theme_color": "#0b0a0d",
+  "background_color": "#0b0a0d"
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow:


### PR DESCRIPTION
Add `robots.txt` from ZDAWebsite and have the colors in manifest match the `index.html` value.