### PR TITLE
Chore: remove phone cases from body text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdaworks-website",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdaworks-website",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "dependencies": {
         "@fontsource/outfit": "^5.0.8",
         "@fontsource/plus-jakarta-sans": "^5.0.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdaworks-website",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/sections/Body/Body.tsx
+++ b/src/sections/Body/Body.tsx
@@ -239,7 +239,7 @@ const Body = () => {
           <p
             className={`m-0 max-w-[30ch] text-sm 3xl:text-base 4xl:text-lg 4k:text-xl text-balance tracking-wide opacity-75 dark:opacity-60 text-zdaText-darker dark:text-zdaText-lighter select-none`}
           >
-            Art prints, posters, phone cases, stickers and more
+            Art prints, posters, cards, stickers and more
           </p>
         </a>
       </div>


### PR DESCRIPTION
### Description
------
INPRNT removed the sale of phone cases, so I swapped that with 'cards' instead.