### PR TITLE
Fix: Manual br on Abstract Media Creation text for mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdaworks-website",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdaworks-website",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@fontsource/outfit": "^5.0.8",
         "@fontsource/plus-jakarta-sans": "^5.0.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdaworks-website",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/sections/Body/Body.tsx
+++ b/src/sections/Body/Body.tsx
@@ -40,7 +40,7 @@ const Body = () => {
                   height={67}
                 />
                 <p className="mt-4 font-outfit text-xl 3xl:text-2xl 4xl:text-3xl 4k:text-4xl tracking-tight font-light text-neutral-800 dark:text-neutral-300 pointer-events-none select-none">
-                  Welcome to the Hub of{" "}
+                  Welcome to the Hub of{" "}<br className="block sm:hidden" />
                   <span className="font-medium tracking-wide ml-[1px]">
                     Abstract Media Creation
                   </span>


### PR DESCRIPTION
### Description
------
- Use `<br />` with a class so that it only breaks on mobile, for the 'Abstract Media Creation' text in the middle